### PR TITLE
fix(favorites): de-duplicate favorites and stop over-marking search results

### DIFF
--- a/radio-browser/assets/radio-browser.css
+++ b/radio-browser/assets/radio-browser.css
@@ -460,6 +460,7 @@
     width: 28px;
     height: 28px;
     font-size: 0.8rem;
+    margin: auto;
 }
 
 .rb-add-btn:hover,

--- a/radio-browser/assets/radio-browser.js
+++ b/radio-browser/assets/radio-browser.js
@@ -85,7 +85,6 @@ function initRadioBrowser($) {
         recentStationData: [],     // Recently played stations (separate to prevent memory leak)
         favoriteStationData: [],   // Favorites section stations
         favorites: [],
-        favoriteNames: [],         // Station names for matching when URLs differ
         favoritesMap: {},
         recentlyPlayed: [],
         countries: [],
@@ -105,36 +104,19 @@ function initRadioBrowser($) {
     }
 
     /**
-     * Normalize name for comparison (lowercase, trim whitespace)
+     * Check if station is in favorites by stream URL.
+     * A favorite's identity is its stream URL (url_resolved), which is also how
+     * moOde stores favorites. Matching by name is intentionally NOT done: distinct
+     * radio-browser entries pointing to the same stream (or sharing a name) must not
+     * all light up as favorited when only one is actually in the list.
      */
-    function normalizeName(name) {
-        if (!name) return '';
-        return name.toLowerCase().trim();
-    }
+    function isInFavorites(url) {
+        if (!url) return false;
 
-    /**
-     * Check if station is in favorites (by URL or name)
-     */
-    function isInFavorites(url, name) {
-        if (!url && !name) return false;
-
-        // Check by URL first
-        if (url) {
-            var normalizedUrl = normalizeUrl(url);
-            for (var i = 0; i < state.favorites.length; i++) {
-                if (normalizeUrl(state.favorites[i]) === normalizedUrl) {
-                    return true;
-                }
-            }
-        }
-
-        // Also check by name (handles different URLs for same station)
-        if (name) {
-            var normalizedName = normalizeName(name);
-            for (var i = 0; i < state.favoriteNames.length; i++) {
-                if (normalizeName(state.favoriteNames[i]) === normalizedName) {
-                    return true;
-                }
+        var normalizedUrl = normalizeUrl(url);
+        for (var i = 0; i < state.favorites.length; i++) {
+            if (normalizeUrl(state.favorites[i]) === normalizedUrl) {
+                return true;
             }
         }
 
@@ -219,9 +201,6 @@ function initRadioBrowser($) {
                     state.favorites = initData.favorites.map(function(f) {
                         return typeof f === 'string' ? f : f.url;
                     });
-                    state.favoriteNames = initData.favorites.map(function(f) {
-                        return typeof f === 'object' && f.name ? f.name : '';
-                    }).filter(function(n) { return n; });
                     state.favoritesMap = {};
                     initData.favorites.forEach(function(f) {
                         var url = typeof f === 'string' ? f : f.url;
@@ -802,7 +781,7 @@ function initRadioBrowser($) {
 
             html.push(buildStationCard(
                 { url: s.url, name: s.name, stationuuid: s.stationuuid, logoUrl: logoUrl, country: s.country, tags: s.tags, bitrate: s.bitrate, codec: s.codec, is_moode: s.is_moode },
-                index, 'rb-recent-card', isInFavorites(s.url, s.name)
+                index, 'rb-recent-card', isInFavorites(s.url)
             ));
         });
 
@@ -1034,6 +1013,25 @@ function initRadioBrowser($) {
             filteredStations = stations.filter(function(s) { return !s.is_moode; });
         }
 
+        // Collapse entries that resolve to the same stream URL. radio-browser.info
+        // often returns several catalog entries per stream; rendering them all clutters
+        // results and makes many cards light up as favorited when only one is in the
+        // list. Keep one card per stream, preferring an entry that carries a logo.
+        var deduped = [];
+        var dedupIndex = {};
+        filteredStations.forEach(function(s) {
+            var key = normalizeUrl((s.url_resolved || s.url || '').trim());
+            if (key === '') { deduped.push(s); return; }
+            if (dedupIndex[key] === undefined) {
+                dedupIndex[key] = deduped.length;
+                deduped.push(s);
+            } else if (!deduped[dedupIndex[key]].favicon && s.favicon) {
+                // Upgrade the kept entry to one that has a logo, keeping its position.
+                deduped[dedupIndex[key]] = s;
+            }
+        });
+        filteredStations = deduped;
+
         $('#rb-result-count').text('(' + filteredStations.length + ' stations)');
         announceToScreenReader(filteredStations.length + ' stations found');
 
@@ -1055,7 +1053,7 @@ function initRadioBrowser($) {
 
             html.push(buildStationCard(
                 { url: stationData.url, name: s.name, stationuuid: s.stationuuid, favicon: s.favicon, country: s.country, tags: s.tags, bitrate: s.bitrate, codec: s.codec, is_moode: s.is_moode },
-                index, '', isInFavorites(stationData.url, stationData.name)
+                index, '', isInFavorites(stationData.url)
             ));
         });
 
@@ -1249,15 +1247,10 @@ function initRadioBrowser($) {
      * This ensures both Recently Played and Search Results cards stay in sync
      */
     function updateFavoriteState(url, isFavorite, stationData) {
-        var name = stationData ? stationData.name : null;
-
         if (isFavorite) {
             // Add to state
-            if (!isInFavorites(url, null)) {
+            if (!isInFavorites(url)) {
                 state.favorites.push(url);
-            }
-            if (name && state.favoriteNames.indexOf(name) === -1) {
-                state.favoriteNames.push(name);
             }
             if (stationData) {
                 state.favoritesMap[url] = stationData;
@@ -1267,12 +1260,6 @@ function initRadioBrowser($) {
             var idx = state.favorites.indexOf(url);
             if (idx > -1) {
                 state.favorites.splice(idx, 1);
-            }
-            if (name) {
-                var nameIdx = state.favoriteNames.indexOf(name);
-                if (nameIdx > -1) {
-                    state.favoriteNames.splice(nameIdx, 1);
-                }
             }
             delete state.favoritesMap[url];
         }

--- a/radio-browser/backend/api.php
+++ b/radio-browser/backend/api.php
@@ -92,6 +92,36 @@ function rb_sql($sql, $params, $dbh)
 }
 
 /**
+ * Normalize a stream URL for comparison (strips scheme, trailing slashes, case).
+ * Mirrors normalizeUrl() in assets/radio-browser.js so front and back agree on identity.
+ */
+function rb_normalize_url($url)
+{
+    $url = trim((string)$url);
+    if ($url === '') return '';
+    $url = preg_replace('#^https?://#i', '', $url);
+    $url = rtrim($url, '/');
+    return strtolower($url);
+}
+
+/**
+ * Collapse duplicate cfg_radio rows for a given stream URL, keeping the lowest id.
+ * cfg_radio has no UNIQUE constraint on station, so the non-atomic check-then-insert
+ * in the import handler can leave identical rows behind. Call after add/promote so the
+ * favorites list self-heals to one row per stream.
+ */
+function rb_dedup_station($url, $dbh)
+{
+    $url = trim((string)$url);
+    if ($url === '') return;
+    rb_sql(
+        "DELETE FROM cfg_radio WHERE station = ? AND id NOT IN (SELECT MIN(id) FROM cfg_radio WHERE station = ?)",
+        [$url, $url],
+        $dbh
+    );
+}
+
+/**
  * Detect if a cfg_radio row is a moOde core station (not imported by Radio Browser).
  * Core stations have metadata (broadcaster/country/region) and home_page != 'radio-browser'.
  */
@@ -1372,6 +1402,7 @@ switch ($cmd) {
             rb_debug_log('Promoting existing station to favorite: ' . $existingName . ' (type: ' . $existingType . ' -> f)');
             $result = rb_sql("UPDATE cfg_radio SET type='f' WHERE station = ?", [$url], $dbh);
             if ($result === true) {
+                rb_dedup_station($url, $dbh);
                 $response = ['success' => true, 'message' => 'Station added to favorites'];
             } else {
                 $response = ['success' => false, 'message' => 'Failed to update station'];
@@ -1456,6 +1487,8 @@ switch ($cmd) {
             $response = ['success' => false, 'message' => 'Failed to add station to database'];
             break;
         }
+        // Collapse any duplicate rows created by a concurrent import of the same stream
+        rb_dedup_station($url, $dbh);
 
         // Create .pls file for MPD (required for moOde Radio Stations browser)
         $plsFile = '/var/lib/mpd/music/RADIO/' . $name . '.pls';
@@ -1529,10 +1562,18 @@ switch ($cmd) {
             $response = ['success' => false, 'message' => 'Database connection failed'];
             break;
         }
-        $result = sqlQuery("SELECT station, name, logo, home_page, broadcaster, country, region, genre, bitrate, format FROM cfg_radio WHERE type='f'", $dbh);
+        $result = sqlQuery("SELECT station, name, logo, home_page, broadcaster, country, region, genre, bitrate, format FROM cfg_radio WHERE type='f' ORDER BY id", $dbh);
         $favorites = [];
+        // Dedup by normalized stream URL: cfg_radio has no UNIQUE constraint on station,
+        // so identical rows can accumulate (races / legacy data). Keep the first seen.
+        $seen = [];
         if (is_array($result)) {
             foreach ($result as $row) {
+                $key = rb_normalize_url($row['station']);
+                if ($key !== '' && isset($seen[$key])) {
+                    continue;
+                }
+                $seen[$key] = true;
                 $favorites[] = [
                     'url' => trim($row['station']),
                     'name' => trim($row['name']),


### PR DESCRIPTION
## Problem

- Favorite stations could appear **multiple times** in the Favorites tab.
- Searching for a station already in favorites lit up the "added" heart on **every** result sharing the same stream, even though only one entry is actually in the list — confusing from a UI/UX standpoint.

## Root cause

moOde's `cfg_radio` table has **no `UNIQUE` constraint on `station`**, so the import handler's non-atomic check-then-insert (plus legacy data) leaves identical favorite rows behind. On top of that, the UI matched favorites by **stream URL *and* name**, so distinct radio-browser.info entries pointing to the same stream (or merely sharing a name) all appeared favorited.

The right identity for a favorite is its **stream URL (`url_resolved`)** — that's also how moOde stores and plays it. (Using `stationuuid` was evaluated and rejected: it conflicts with moOde's URL-based favorite storage, e.g. it would show an "Add" button that then refuses with "already in favorites".)

## Changes

**Backend (`backend/api.php`)**
- `rb_normalize_url()` helper (mirrors the JS one).
- `cmd=favorites` now **de-duplicates by normalized stream URL** on read, so duplicates never render even if present in the DB.
- `rb_dedup_station()` **self-heals** duplicate rows (keeps lowest `id`) after add/promote in `import`, preventing accumulation going forward.

**Frontend (`assets/radio-browser.js`)**
- Search results are **collapsed by `url_resolved`**, preferring a candidate that carries a favicon/logo — one card per stream.
- `isInFavorites()` now matches by **stream URL only**; removed the overly-broad name fallback and the now-dead `favoriteNames` / `normalizeName` code.

## Testing

Verified live on a moOde 10.2.4:
- Existing duplicates (`Radio Choco` ×4, `France Info` ×3) collapse to one entry each; favorites count 10 → 5.
- Real search for "radio choco": **8 raw results → 3** (one per stream), each kept card carries a logo (favicon preference confirmed).
- The single favorited stream now shows **one** highlighted card instead of four.
- `php -l` and `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
